### PR TITLE
[YLS-2] Yahoo Finance Scraping Apex

### DIFF
--- a/force-app/main/default/classes/YahooFinanceScraping.cls
+++ b/force-app/main/default/classes/YahooFinanceScraping.cls
@@ -1,0 +1,165 @@
+public with sharing class YahooFinanceScraping {
+    @AuraEnabled
+    public static List<YahooFinanceScraping.YahooFinanceHTMLWrapper> scrapeHTML(List<String> tickers, String givenDateMiliseconds, String givenDateMilisecondsPlusOneDay) {
+
+        System.debug('tickers: ' + tickers);
+
+        System.debug(givenDateMiliseconds);
+        System.debug(givenDateMilisecondsPlusOneDay);
+
+        List<YahooFinanceHTMLWrapper> yahooTickerWrapperList = new List<YahooFinanceHTMLWrapper>();
+
+        
+      
+        for(String ticker : tickers){
+
+            String stockUrl = 'https://finance.yahoo.com/quote/' + ticker+ '/history?period1='+ givenDateMiliseconds +'&period2='+ givenDateMilisecondsPlusOneDay +'&interval=1d&filter=history&frequency=1d&includeAdjustedClose=true';
+            String companyUrl = 'https://finance.yahoo.com/quote/' + ticker+ '/profile?p=' + ticker;
+            String marketCapUrl = 'https://finance.yahoo.com/quote/' + ticker+ '?p=' + ticker;
+
+            System.debug('stockUrl: ' + stockUrl);
+
+            List<String> urls = new List<String>{stockUrl, companyUrl, marketCapUrl};
+    
+            YahooFinanceHTMLWrapper yfw = makeCallout(urls);
+            yfw.ticker = ticker;
+            yahooTickerWrapperList.add(yfw);
+
+        }
+        return yahooTickerWrapperList;
+    }
+
+    private static YahooFinanceHTMLWrapper makeCallout(List<String> urls){
+
+        YahooFinanceHTMLWrapper yfw = new YahooFinanceHTMLWrapper();
+        HttpResponse response;
+
+
+        for(Integer i=0; i<3; i++){
+
+            try {
+
+                HttpRequest request = new HttpRequest();
+                Http http = new Http();
+
+                request.setEndpoint(urls[i]);
+                request.setMethod('GET');
+
+                response = http.send(request);
+
+
+                if (response.getStatusCode() == 200) {
+
+                    if(i==0){
+                        yfw.stockData = response.getBody();
+                    }else if(i==1){
+                        yfw.companyInfo = response.getBody();
+                    }else if(i==2){
+                        yfw.marketCap = response.getBody();
+                    }
+                } 
+
+            } catch (Exception e) {
+                throw new AuraHandledException('Failed to retrieve HTML. Status code: ' + response.getStatusCode() + ' Response: ' + response.getBody());
+            }
+        }
+
+        return yfw;
+
+    }
+
+    //method to insert the stock data
+   
+
+    @AuraEnabled
+    public static List<YahooLWCResponse> insertStockData(String stockDataList){
+        
+        System.debug('stockDataList: ' + stockDataList);
+
+        List<YahooLWCResponse> ywrList = (List<YahooLWCResponse>) JSON.deserialize(stockDataList, List<YahooLWCResponse>.class);
+
+        List<Scraped_Data__c> stockList = new List<Scraped_Data__c>();
+
+        for(YahooLWCResponse ywr : ywrList){
+
+
+            Scraped_Data__c sd = new Scraped_Data__c();
+            sd.Name = ywr.ticker + ' ' + ywr.givenDate;
+            sd.Ticker_Symbol__c = ywr.ticker;
+            sd.Date__c = Date.valueOf(ywr.givenDate);
+            sd.Open_Price__c = Decimal.valueOf(ywr.openPrice);
+            sd.Close_Price__c = Decimal.valueOf(ywr.closePrice);
+            sd.Market_Cap__c = String.valueOf(ywr.marketCap);
+            sd.Employee_Number__c = ywr.employeeNumber;
+            sd.Company_Address__c = ywr.companyAddress;
+            sd.Industry__c = ywr.industry;
+
+            stockList.add(sd);
+        }
+
+        try {
+            Database.SaveResult[] results = Database.insert(stockList, false);
+            Set<ID> stockIds = new Set<ID>();
+            for(Integer i=0; i<results.size(); i++){
+                Database.SaveResult sr = results[i];
+                if(sr.isSuccess()){
+                    ywrList[i].id = sr.getId();
+                    stockIds.add(sr.getId());
+                }else {
+                    Database.Error err = sr.getErrors()[0];
+                    ywrList[i].success = false;
+                    ywrList[i].errorMessage = err.getMessage();
+                }
+            }
+
+            return ywrList;
+        
+
+        } catch (Exception e) {
+            System.debug('Failed to insert stock data. Error: ' + e.getMessage());
+            throw new AuraHandledException('Failed to insert stock data. Error: ' + e.getMessage());
+        }
+    }
+
+
+
+
+    public class YahooLWCResponse{
+        @AuraEnabled
+        public String ticker;
+        @AuraEnabled
+        public String givenDate;
+        @AuraEnabled
+        public String openPrice;
+        @AuraEnabled
+        public String closePrice;
+        @AuraEnabled
+        public String marketCap;
+        @AuraEnabled
+        public String employeeNumber;
+        @AuraEnabled
+        public String companyAddress;
+        @AuraEnabled
+        public String industry;
+        @AuraEnabled
+        public String name;
+        @AuraEnabled
+        public String id;
+        @AuraEnabled 
+        public Boolean success;
+        @AuraEnabled
+        public String errorMessage;
+    }
+
+    public class YahooFinanceHTMLWrapper {
+        @AuraEnabled 
+        public String ticker;
+        @AuraEnabled
+        public String stockData; 
+        @AuraEnabled
+        public String companyInfo; 
+        @AuraEnabled
+        public String marketCap; 
+    }
+
+}

--- a/force-app/main/default/classes/YahooFinanceScraping.cls
+++ b/force-app/main/default/classes/YahooFinanceScraping.cls
@@ -31,11 +31,11 @@ public with sharing class YahooFinanceScraping {
     //todo:
     //perform duplicate checks prior to making callouts
     @AuraEnabled
-    public static List<Stock_Data__c> verifyDuplicates(List<String> tickers, Date givenDate){
+    public static List<Stock_Data__c> verifyDuplicates(List<String> tickers, String givenDateStr){
         try {
-            //if ticker has data for the given date, return string with tickers that already have data
-            // should I return the data as well?
-
+            
+            Date givenDate = Date.valueOf(givenDateStr);
+            
             List<Stock_Data__c> stockData = YahooFinanceScrapingDAO.findScrapedData(tickers,givenDate);
             return stockData;
             

--- a/force-app/main/default/classes/YahooFinanceScraping.cls
+++ b/force-app/main/default/classes/YahooFinanceScraping.cls
@@ -1,16 +1,14 @@
 public with sharing class YahooFinanceScraping {
+
+    //we have 2 givenDate params since yahoo historical requires 2 time points
+    // the second param is +1 day due to Yahoo not rendering if they are the same
     @AuraEnabled
-    public static List<YahooFinanceScraping.YahooFinanceHTMLWrapper> scrapeHTML(List<String> tickers, String givenDateMiliseconds, String givenDateMilisecondsPlusOneDay) {
+    public static List<YahooFinanceHTMLWrapper> scrapeHTML(List<String> tickers, String givenDateMiliseconds, String givenDateMilisecondsPlusOneDay) {
 
         System.debug('tickers: ' + tickers);
 
-        System.debug(givenDateMiliseconds);
-        System.debug(givenDateMilisecondsPlusOneDay);
-
         List<YahooFinanceHTMLWrapper> yahooTickerWrapperList = new List<YahooFinanceHTMLWrapper>();
 
-        
-      
         for(String ticker : tickers){
 
             String stockUrl = 'https://finance.yahoo.com/quote/' + ticker+ '/history?period1='+ givenDateMiliseconds +'&period2='+ givenDateMilisecondsPlusOneDay +'&interval=1d&filter=history&frequency=1d&includeAdjustedClose=true';
@@ -33,7 +31,6 @@ public with sharing class YahooFinanceScraping {
 
         YahooFinanceHTMLWrapper yfw = new YahooFinanceHTMLWrapper();
         HttpResponse response;
-
 
         for(Integer i=0; i<3; i++){
 
@@ -65,19 +62,27 @@ public with sharing class YahooFinanceScraping {
         }
 
         return yfw;
-
     }
 
-    //method to insert the stock data
+
+    //todo:
+    //perform duplicate checks prior to making callouts
+    @AuraEnabled
+    public static List<String> verifyDuplicates(List<String> tickers, Date givenDate){
+        try {
+            //if ticker has data for the given date, return string with tickers that already have data
+            // should I return the data as well?
+            
+        } catch (Exception e) {
+            throw new AuraHandledException(e.getMessage());
+        }
+    }
    
 
     @AuraEnabled
     public static List<YahooLWCResponse> insertStockData(String stockDataList){
         
-        System.debug('stockDataList: ' + stockDataList);
-
         List<YahooLWCResponse> ywrList = (List<YahooLWCResponse>) JSON.deserialize(stockDataList, List<YahooLWCResponse>.class);
-
         List<Scraped_Data__c> stockList = new List<Scraped_Data__c>();
 
         for(YahooLWCResponse ywr : ywrList){
@@ -98,23 +103,10 @@ public with sharing class YahooFinanceScraping {
         }
 
         try {
-            Database.SaveResult[] results = Database.insert(stockList, false);
-            Set<ID> stockIds = new Set<ID>();
-            for(Integer i=0; i<results.size(); i++){
-                Database.SaveResult sr = results[i];
-                if(sr.isSuccess()){
-                    ywrList[i].id = sr.getId();
-                    stockIds.add(sr.getId());
-                }else {
-                    Database.Error err = sr.getErrors()[0];
-                    ywrList[i].success = false;
-                    ywrList[i].errorMessage = err.getMessage();
-                }
-            }
+            Database.SaveResult[] results = Database.insert(stockList, false);            
 
-            return ywrList;
-        
-
+            //we use the same wrapper to send the info back
+            return addInsertResultsToWrapper(results, ywrList);
         } catch (Exception e) {
             System.debug('Failed to insert stock data. Error: ' + e.getMessage());
             throw new AuraHandledException('Failed to insert stock data. Error: ' + e.getMessage());
@@ -122,8 +114,29 @@ public with sharing class YahooFinanceScraping {
     }
 
 
+    /////////
+    //helper methods
+    /////////
+    private static List<YahooLWCResponse> addInsertResultsToWrapper(List<Database.SaveResult> results, List<YahooLWCResponse> yahooLWCResponses ){
+
+        List<YahooLWCResponse> ylrList = new List<YahooLWCResponse>(YahooLWCResponse);
+
+        for(Integer i=0; i<results.size(); i++){
+            Database.SaveResult sr = results[i];
+            if(sr.isSuccess()){
+                ylrList[i].id = sr.getId();
+            }else {
+                Database.Error err = sr.getErrors()[0];
+                ylrList[i].success = false;
+                ylrList[i].errorMessage = err.getMessage();
+            }
+        }
+
+        return ylrList;
+    }
 
 
+    
     public class YahooLWCResponse{
         @AuraEnabled
         public String ticker;
@@ -150,6 +163,7 @@ public with sharing class YahooFinanceScraping {
         @AuraEnabled
         public String errorMessage;
     }
+
 
     public class YahooFinanceHTMLWrapper {
         @AuraEnabled 

--- a/force-app/main/default/classes/YahooFinanceScraping.cls
+++ b/force-app/main/default/classes/YahooFinanceScraping.cls
@@ -1,35 +1,19 @@
-public with sharing class YahooFinanceScraping {
+public class YahooFinanceScraping {
 
     //we have 2 givenDate params since yahoo historical requires 2 time points
     // the second param is +1 day due to Yahoo not rendering if they are the same
     @AuraEnabled
-    public static List<YahooFinanceHTMLWrapper> scrapeHTML(List<String> tickers, String givenDateMiliseconds, String givenDateMilisecondsPlusOneDay) {
-
-        System.debug('tickers: ' + tickers);
-
+    public static YahooFinanceHTMLWrapper scrapeHTML(String ticker, String givenDateMiliseconds, String givenDateMilisecondsPlusOneDay) {
+        System.debug('ticker: ' + ticker);
         List<YahooFinanceHTMLWrapper> yahooTickerWrapperList = new List<YahooFinanceHTMLWrapper>();
-
-        for(String ticker : tickers){
-
-            String stockUrl = 'https://finance.yahoo.com/quote/' + ticker+ '/history?period1='+ givenDateMiliseconds +'&period2='+ givenDateMilisecondsPlusOneDay +'&interval=1d&filter=history&frequency=1d&includeAdjustedClose=true';
-            String companyUrl = 'https://finance.yahoo.com/quote/' + ticker+ '/profile?p=' + ticker;
-            String marketCapUrl = 'https://finance.yahoo.com/quote/' + ticker+ '?p=' + ticker;
-
-            System.debug('stockUrl: ' + stockUrl);
-
-            List<String> urls = new List<String>{stockUrl, companyUrl, marketCapUrl};
     
-            YahooFinanceHTMLWrapper yfw = YahooFinanceScrapingHelper.makeCallout(urls);
-            yfw.ticker = ticker;
-            yahooTickerWrapperList.add(yfw);
-
-        }
-        return yahooTickerWrapperList;
+        YahooFinanceHTMLWrapper yfw = YahooFinanceScrapingHelper.fetchStockData(ticker, givenDateMiliseconds, givenDateMilisecondsPlusOneDay);
+        yfw.ticker = ticker;
+       
+        return yfw;
     }
+    
 
-
-    //todo:
-    //perform duplicate checks prior to making callouts
     @AuraEnabled
     public static List<Stock_Data__c> verifyDuplicates(List<String> tickers, String givenDateStr){
         try {

--- a/force-app/main/default/classes/YahooFinanceScraping.cls
+++ b/force-app/main/default/classes/YahooFinanceScraping.cls
@@ -19,7 +19,7 @@ public with sharing class YahooFinanceScraping {
 
             List<String> urls = new List<String>{stockUrl, companyUrl, marketCapUrl};
     
-            YahooFinanceHTMLWrapper yfw = makeCallout(urls);
+            YahooFinanceHTMLWrapper yfw = YahooFinanceScrapingHelper.makeCallout(urls);
             yfw.ticker = ticker;
             yahooTickerWrapperList.add(yfw);
 
@@ -27,51 +27,17 @@ public with sharing class YahooFinanceScraping {
         return yahooTickerWrapperList;
     }
 
-    private static YahooFinanceHTMLWrapper makeCallout(List<String> urls){
-
-        YahooFinanceHTMLWrapper yfw = new YahooFinanceHTMLWrapper();
-        HttpResponse response;
-
-        for(Integer i=0; i<3; i++){
-
-            try {
-
-                HttpRequest request = new HttpRequest();
-                Http http = new Http();
-
-                request.setEndpoint(urls[i]);
-                request.setMethod('GET');
-
-                response = http.send(request);
-
-
-                if (response.getStatusCode() == 200) {
-
-                    if(i==0){
-                        yfw.stockData = response.getBody();
-                    }else if(i==1){
-                        yfw.companyInfo = response.getBody();
-                    }else if(i==2){
-                        yfw.marketCap = response.getBody();
-                    }
-                } 
-
-            } catch (Exception e) {
-                throw new AuraHandledException('Failed to retrieve HTML. Status code: ' + response.getStatusCode() + ' Response: ' + response.getBody());
-            }
-        }
-
-        return yfw;
-    }
-
 
     //todo:
     //perform duplicate checks prior to making callouts
     @AuraEnabled
-    public static List<String> verifyDuplicates(List<String> tickers, Date givenDate){
+    public static List<Stock_Data__c> verifyDuplicates(List<String> tickers, Date givenDate){
         try {
             //if ticker has data for the given date, return string with tickers that already have data
             // should I return the data as well?
+
+            List<Stock_Data__c> stockData = YahooFinanceScrapingDAO.findScrapedData(tickers,givenDate);
+            return stockData;
             
         } catch (Exception e) {
             throw new AuraHandledException(e.getMessage());
@@ -83,12 +49,12 @@ public with sharing class YahooFinanceScraping {
     public static List<YahooLWCResponse> insertStockData(String stockDataList){
         
         List<YahooLWCResponse> ywrList = (List<YahooLWCResponse>) JSON.deserialize(stockDataList, List<YahooLWCResponse>.class);
-        List<Scraped_Data__c> stockList = new List<Scraped_Data__c>();
+        List<Stock_Data__c> stockList = new List<Stock_Data__c>();
 
         for(YahooLWCResponse ywr : ywrList){
 
 
-            Scraped_Data__c sd = new Scraped_Data__c();
+            Stock_Data__c sd = new Stock_Data__c();
             sd.Name = ywr.ticker + ' ' + ywr.givenDate;
             sd.Ticker_Symbol__c = ywr.ticker;
             sd.Date__c = Date.valueOf(ywr.givenDate);
@@ -119,7 +85,7 @@ public with sharing class YahooFinanceScraping {
     /////////
     private static List<YahooLWCResponse> addInsertResultsToWrapper(List<Database.SaveResult> results, List<YahooLWCResponse> yahooLWCResponses ){
 
-        List<YahooLWCResponse> ylrList = new List<YahooLWCResponse>(YahooLWCResponse);
+        List<YahooLWCResponse> ylrList = new List<YahooLWCResponse>(yahooLWCResponses);
 
         for(Integer i=0; i<results.size(); i++){
             Database.SaveResult sr = results[i];

--- a/force-app/main/default/classes/YahooFinanceScraping.cls-meta.xml
+++ b/force-app/main/default/classes/YahooFinanceScraping.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/YahooFinanceScrapingDAO.cls
+++ b/force-app/main/default/classes/YahooFinanceScrapingDAO.cls
@@ -1,0 +1,9 @@
+public with sharing class YahooFinanceScrapingDAO {
+   
+    public static List<Stock_Data__c> findScrapedData(List<String> tickers, Date givenDate){
+
+        return [SELECT ID,Ticker_Symbol__c 
+                FROM Stock_Data__c 
+                WHERE Ticker_Symbol__c IN :tickers];
+    }
+}

--- a/force-app/main/default/classes/YahooFinanceScrapingDAO.cls
+++ b/force-app/main/default/classes/YahooFinanceScrapingDAO.cls
@@ -4,6 +4,7 @@ public with sharing class YahooFinanceScrapingDAO {
 
         return [SELECT ID,Ticker_Symbol__c 
                 FROM Stock_Data__c 
-                WHERE Ticker_Symbol__c IN :tickers];
+                WHERE Ticker_Symbol__c IN :tickers AND
+                Date__c = :givenDate];
     }
 }

--- a/force-app/main/default/classes/YahooFinanceScrapingDAO.cls-meta.xml
+++ b/force-app/main/default/classes/YahooFinanceScrapingDAO.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/YahooFinanceScrapingHelper.cls
+++ b/force-app/main/default/classes/YahooFinanceScrapingHelper.cls
@@ -1,0 +1,40 @@
+public with sharing class YahooFinanceScrapingHelper {
+    
+    
+    public static YahooFinanceScraping.YahooFinanceHTMLWrapper makeCallout(List<String> urls){
+
+        YahooFinanceScraping.YahooFinanceHTMLWrapper yfw = new YahooFinanceScraping.YahooFinanceHTMLWrapper();
+        HttpResponse response;
+
+        for(Integer i=0; i<3; i++){
+
+            try {
+
+                HttpRequest request = new HttpRequest();
+                Http http = new Http();
+
+                request.setEndpoint(urls[i]);
+                request.setMethod('GET');
+
+                response = http.send(request);
+
+
+                if (response.getStatusCode() == 200) {
+
+                    if(i==0){
+                        yfw.stockData = response.getBody();
+                    }else if(i==1){
+                        yfw.companyInfo = response.getBody();
+                    }else if(i==2){
+                        yfw.marketCap = response.getBody();
+                    }
+                } 
+
+            } catch (Exception e) {
+                throw new AuraHandledException('Failed to retrieve HTML. Status code: ' + response.getStatusCode() + ' Response: ' + response.getBody());
+            }
+        }
+
+        return yfw;
+    }
+}

--- a/force-app/main/default/classes/YahooFinanceScrapingHelper.cls
+++ b/force-app/main/default/classes/YahooFinanceScrapingHelper.cls
@@ -1,40 +1,44 @@
 public with sharing class YahooFinanceScrapingHelper {
     
-    
-    public static YahooFinanceScraping.YahooFinanceHTMLWrapper makeCallout(List<String> urls){
-
+    public static YahooFinanceScraping.YahooFinanceHTMLWrapper fetchStockData(String ticker, String givenDateMiliseconds, String givenDateMilisecondsPlusOneDay) {
         YahooFinanceScraping.YahooFinanceHTMLWrapper yfw = new YahooFinanceScraping.YahooFinanceHTMLWrapper();
-        HttpResponse response;
-
-        for(Integer i=0; i<3; i++){
-
-            try {
-
-                HttpRequest request = new HttpRequest();
-                Http http = new Http();
-
-                request.setEndpoint(urls[i]);
-                request.setMethod('GET');
-
-                response = http.send(request);
-
-
-                if (response.getStatusCode() == 200) {
-
-                    if(i==0){
-                        yfw.stockData = response.getBody();
-                    }else if(i==1){
-                        yfw.companyInfo = response.getBody();
-                    }else if(i==2){
-                        yfw.marketCap = response.getBody();
-                    }
-                } 
-
-            } catch (Exception e) {
-                throw new AuraHandledException('Failed to retrieve HTML. Status code: ' + response.getStatusCode() + ' Response: ' + response.getBody());
+        String stockUrl = 'https://finance.yahoo.com/quote/' + ticker + '/history?period1=' + givenDateMiliseconds + '&period2=' + givenDateMilisecondsPlusOneDay + '&interval=1d&filter=history&frequency=1d&includeAdjustedClose=true';
+        String companyUrl = 'https://finance.yahoo.com/quote/' + ticker + '/profile?p=' + ticker;
+        String marketCapUrl = 'https://finance.yahoo.com/quote/' + ticker + '?p=' + ticker;
+    
+        List<String> urls = new List<String>{stockUrl, companyUrl, marketCapUrl};
+    
+        for (String url : urls) {
+            HttpResponse response = YahooFinanceScrapingHelper.makeCallout(url);
+    
+            if (response.getStatusCode() == 200) {
+                if (url == stockUrl) {
+                    yfw.stockData = response.getBody();
+                } else if (url == companyUrl) {
+                    yfw.companyInfo = response.getBody();
+                } else if (url == marketCapUrl) {
+                    yfw.marketCap = response.getBody();
+                }
             }
         }
-
+    
         return yfw;
+    }
+
+    
+    private static HttpResponse makeCallout(String url) {
+        HttpRequest request = new HttpRequest();
+        Http http = new Http();
+        request.setEndpoint(url);
+        request.setMethod('GET');
+        HttpResponse response;
+
+        try {
+            response = http.send(request);
+        } catch (Exception e) {
+            throw new AuraHandledException('Failed to retrieve HTML. Error: ' + e.getMessage());
+        }
+
+        return response;
     }
 }

--- a/force-app/main/default/classes/YahooFinanceScrapingHelper.cls-meta.xml
+++ b/force-app/main/default/classes/YahooFinanceScrapingHelper.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>57.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
This apex class receives a list of tickers and 2 given dates in miliseconds parameters from LWC. Why 2 given dates? The first one is the exact date for which we need the data for, while the second one is a day after. 

The Yahoo Finance! requires 2 days in order to load the historical view:
finance.yahoo.com/quote/AAPL/history?period1=**1672617600**&period2=**1672704000**

If we were to specify the period as the same, the page wouldn't load any data.

We send the callouts to 3 YH pages:
- historical data
- current data
- company info

and with the above, we extract data such as:
- Company information
- industry
- open price
- close price
- market cap
- number of employees


